### PR TITLE
feat: enhance post-annotations to support both workflow_run and same-workflow scenarios

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -395,21 +395,38 @@ runs:
         overwrite: true
         path: ${{ env.TRUNK_TMPDIR }}/annotations.bin
 
-    - name: Download annotations artifact
-      if: inputs.post-annotations == 'true'
+    - name: Download annotations artifact (same workflow)
+      if: inputs.post-annotations == 'true' && github.event.workflow_run.id == ''
+      uses: actions/download-artifact@v4
+      continue-on-error: true
+      id: download-same-workflow
+      with:
+        name: trunk-annotations
+        path: ${{ env.TRUNK_TMPDIR }}
+
+    - name: Download annotations artifact (workflow_run or fallback)
+      if: inputs.post-annotations == 'true' && (github.event.workflow_run.id != '' || steps.download-same-workflow.outcome == 'failure')
       uses: actions/github-script@v7
       with:
-        # TODO(chris): We can't use the official download artifact action yet: https://github.com/actions/download-artifact/issues/172
+        # TODO(chris): We can't use the official download artifact action yet for workflow_run: https://github.com/actions/download-artifact/issues/172
         script: |
+          // Use workflow_run.id if available (when triggered by workflow_run event),
+          // otherwise fall back to github.run_id (for same-workflow scenarios where download-artifact failed)
+          let runId = ${{ github.event.workflow_run.id || github.run_id }};
+          console.log(`Attempting to download artifacts from run ${runId}`);
+          
           let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }},
+              run_id: runId,
           });
+          
           let matchArtifact = artifacts.data.artifacts.filter((artifact) => {
             return artifact.name == "trunk-annotations"
           })[0];
+          
           if (matchArtifact) {
+            console.log(`Found trunk-annotations artifact with ID ${matchArtifact.id}`);
             let download = await github.rest.actions.downloadArtifact({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
@@ -418,13 +435,17 @@ runs:
             });
             let fs = require('fs');
             fs.writeFileSync('${{ env.TRUNK_TMPDIR }}/annotations.zip', Buffer.from(download.data));
+          } else {
+            console.log('No trunk-annotations artifact found');
           }
 
     - name: Unpack annotations artifact
-      if: inputs.post-annotations == 'true'
+      if: inputs.post-annotations == 'true' && github.event.workflow_run.id != ''
       run: |
-        # Unpack annotations artifact
-        cd ${{ env.TRUNK_TMPDIR }} && unzip annotations.zip
+        # Unpack annotations artifact (only needed for workflow_run scenario)
+        if [[ -f "${{ env.TRUNK_TMPDIR }}/annotations.zip" ]]; then
+          cd ${{ env.TRUNK_TMPDIR }} && unzip annotations.zip
+        fi
       shell: bash
 
     - name: Post annotations
@@ -434,7 +455,8 @@ runs:
         # Post annotations
         ${GITHUB_ACTION_PATH}/annotate.sh
       env:
-        GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        # Use workflow_run.head_sha if available (fork PR scenario), otherwise use the current SHA
+        GITHUB_EVENT_WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
 
     - name: Upload landing state
       if: env.INPUT_UPLOAD_LANDING_STATE == 'true'


### PR DESCRIPTION
## Summary

This PR enhances the `post-annotations` functionality to work in both workflow_run scenarios (fork PRs) and same-workflow scenarios (regular PRs with split jobs).

## Changes

- Added dual download strategy for annotations artifacts:
  - First attempts to use `actions/download-artifact@v4` for same-workflow scenarios
  - Falls back to GitHub API approach for workflow_run events or if the first attempt fails
- Updated run ID handling to support both `github.event.workflow_run.id` and `github.run_id`
- Enhanced commit SHA handling for both fork PR and regular PR scenarios
- Added console logging for better debugging

## Use Cases

This enhancement supports three scenarios:

1. **Fork PRs** (existing functionality preserved):
   - PR workflow saves annotations as artifact
   - Separate workflow triggered by `workflow_run` downloads and posts them

2. **Regular PRs with split jobs** (new functionality):
   - Job 1: Runs trunk check with `save-annotations: true`
   - Job 2: Uses `post-annotations: true` to download and post annotations from same workflow

3. **Regular PRs** (existing direct posting still works):
   - Single job can still post annotations directly without artifacts

## Testing

The changes maintain backward compatibility while adding new capabilities. The fallback mechanism ensures that if one approach fails, the other is attempted.

## Related Issues

Addresses the limitation where `post-annotations` only worked with workflow_run events, now enabling its use in regular branch PRs with split-job configurations.